### PR TITLE
Use $pages instead of $files for creating navbar

### DIFF
--- a/config.php
+++ b/config.php
@@ -6,7 +6,6 @@
 
 	// Exclude the following top levels
 	'exclude' => array(
-		'404',
 	),
 
 	// Prints the hierarchy (with print_r)


### PR DESCRIPTION
I rewritten part of your plugin to use $pages from pages repository `findAll` method, so that ordering configured for CMS is respected. Also, 404 exclusion isn't necessary because it isn't included in pages array.
